### PR TITLE
Add support for single-line comments

### DIFF
--- a/shen-mode.el
+++ b/shen-mode.el
@@ -308,8 +308,9 @@
                     (?>  . "w")
                     (?/  . "w")
                     ;; comment delimiters
-                    (?\\ . ". 14")
-                    (?*  . ". 23")))
+                    (?\\ . ". 124b")
+                    (?*  . ". 23")
+                    (?\n . "> b")))
       (modify-syntax-entry (car pair) (cdr pair) table))
     table)
   "Syntax table to use in shen-mode.")


### PR DESCRIPTION
Shen 10 added support for single-line comments starting with '\'.

This pull request makes the required changes to shen-mode-syntax-table to support them.
